### PR TITLE
create Apache Giraph-compatible facebook jars.

### DIFF
--- a/copy-hdfs-jars-to-maven.sh
+++ b/copy-hdfs-jars-to-maven.sh
@@ -9,14 +9,14 @@ BASEDIR=`dirname $0`
 cd ${BASEDIR}
 
 if [ ! -f build/hadoop-0.20.1-dev-core.jar ]; then
- if [ ! -f build/hadoop-0.20-core.jar ]; then
+ if [ ! -f build/hadoop-0.20.1-core.jar ]; then
   echo "core jar not found. Running 'ant jar'..."
   ant jar | grep BUILD;
  fi
 fi
 
 if [ ! -f build/hadoop-0.20.1-dev-test.jar ]; then
- if [ ! -f build/hadoop-0.20-test.jar ]; then
+ if [ ! -f build/hadoop-0.20.1-test.jar ]; then
    echo "test jar not found. Running 'ant jar-test'..."
    ant jar-test | grep BUILD;
  fi
@@ -32,7 +32,7 @@ fi
 if [ -f build/hadoop-0.20.1-dev-core.jar ]; then
   CORE_JAR=build/hadoop-0.20.1-dev-core.jar
 else
-  CORE_JAR=build/hadoop-0.20-core.jar
+  CORE_JAR=build/hadoop-0.20.1-core.jar
 fi
 
 if [ -f build/hadoop-0.20.1-dev-test.jar ]; then
@@ -48,16 +48,16 @@ echo "** HBase builds will  pick up the HDFS* jars from the local maven repo."
 
 mvn install:install-file \
     -DgeneratePom=true \
-    -DgroupId=org.apache.hadoop \
+    -DgroupId=com.facebook.hadoop \
     -DartifactId=hadoop-core \
-    -Dversion=0.20 \
+    -Dversion=0.20.1 \
     -Dpackaging=jar \
     -Dfile=${CORE_JAR}
 
 mvn install:install-file \
     -DgeneratePom=true \
-    -DgroupId=org.apache.hadoop \
+    -DgroupId=com.facebook.hadoop \
     -DartifactId=hadoop-test \
-    -Dversion=0.20 \
+    -Dversion=0.20.1 \
     -Dpackaging=jar \
     -Dfile=${TEST_JAR}


### PR DESCRIPTION
Giraph (http://giraph.apache.org)'s facebook profile has the following:

```
<dependency>
      <groupId>com.facebook.hadoop</groupId>
      <artifactId>hadoop-core</artifactId>
      <version>0.20.1</version>
      <type>jar</type>
      <scope>system</scope>
      <systemPath>${hadoop.jar.path}</systemPath>
</dependency>
```

However Facebook's build.xml and copy-hdfs-jars-to-maven.sh do not conform to this.
